### PR TITLE
set PATH to accomodate existing PATHS

### DIFF
--- a/core/Dockerfile.rhel8
+++ b/core/Dockerfile.rhel8
@@ -25,7 +25,7 @@ ENV \
     APP_ROOT=/opt/app-root \
     # The $HOME is not set by default, but some applications needs this variable
     HOME=/opt/app-root/src \
-    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH} \
     PLATFORM="el8"
 
 # Copy just prepare-yum-repositories that is needed for packages install step,


### PR DESCRIPTION
set PATH to accommodate existing PATHS
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://issues.redhat.com/browse/RHODS-1468
The base image PATHS is getting overwritten, which causes issues in finding the necessary binaries.


Requires new tag.